### PR TITLE
Modify grub2 configurate file in Ubuntu14.04 and test it pass

### DIFF
--- a/_grub_grub2_config/grub2_config_with_ubuntu_14_04.txt
+++ b/_grub_grub2_config/grub2_config_with_ubuntu_14_04.txt
@@ -1,0 +1,4 @@
+menuentry 'myKernel' {
+	set root='hd0,msdos1'     ;the device of your /boot, such as hd0,sda1
+	multiboot /kernel-7001 ro ;you should put this file in /boot
+}


### PR DESCRIPTION
In Ubuntu14.04 it has a little different, you needn't get /boot/kernel-<version>,just use /kernel-<version> and it will work well.
