### PR TITLE
Fix missing parentheses. Add Ubuntu 14.04 GRUB2 instructions. Use Markdown.

### DIFF
--- a/_grub_grub2_config/README.md
+++ b/_grub_grub2_config/README.md
@@ -1,0 +1,13 @@
+# Sample grub.cfg for GRUB and GRUB2.
+Thanks to Rubén Laguna for the providing GRUB2 config.
+
+## Install and use mkernel on Ubuntu 14.04
+```
+sudo vim /etc/grub.d/40_custom
+```
+* Add the contents of `grub2_config.txt` to the end of the file
+
+```
+sudo update-grub && sudo reboot now
+```
+* Select `myKernel` at the Grub menu screen

--- a/_grub_grub2_config/grub2_config.txt
+++ b/_grub_grub2_config/grub2_config.txt
@@ -1,4 +1,4 @@
 menuentry 'myKernel' {
-	set root='hd0,msdos1'
-	multiboot /boot/kernel-7001 ro
+	set root='(hd0,msdos1)'
+	multiboot /boot/kernel-701 ro
 }

--- a/_grub_grub2_config/readme.txt
+++ b/_grub_grub2_config/readme.txt
@@ -1,2 +1,0 @@
-Sample grub.cfg for GRUB and GRUB2.
-Thanks to Rubén Laguna for the providing GRUB2 config.


### PR DESCRIPTION
This fixes the GRUB2 `menuentry` [issue](https://github.com/arjun024/mkernel/issues/6) and adds Ubuntu 14.04 install instructions in Markdown format.