### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,13 @@ This is a minimalist kernel which prints "`my first kernel`" on the screen and t
 * The kernel is Multiboot compliant and loads with GRUB.
 
 
-####Blog post####
+#### Blog post ####
 
 Kernel 101 – Let’s write a Kernel
 
 (http://arjunsreedharan.org/post/82710718100/kernel-101-lets-write-a-kernel)
 
-####Build commands####
+#### Build commands ####
 ```
 nasm -f elf32 kernel.asm -o kasm.o
 ```
@@ -23,12 +23,12 @@ gcc -m32 -c kernel.c -o kc.o
 ld -m elf_i386 -T link.ld -o kernel kasm.o kc.o
 ```
 
-####Test on emulator####
+#### Test on emulator ####
 ```
 qemu-system-i386 -kernel kernel
 ```
 
-####Get to boot####
+#### Get to boot ####
 GRUB requires your kernel executable to be of the pattern `kernel-<version>`.
 
 So, rename the kernel:
@@ -51,5 +51,5 @@ Voila !!
 
 ![kernel screenshot](http://static.tumblr.com/gltvynn/yOdn443dr/mkernel.png "Screenshot")
 
-####The next step####
+#### The next step ####
 see [mkeykernel repo](//github.com/arjun024/mkeykernel)


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
